### PR TITLE
Always set next game to null on click

### DIFF
--- a/src/views/hilo.tsx
+++ b/src/views/hilo.tsx
@@ -92,6 +92,7 @@ export default function Hilo(props: Props) {
   }
 
   async function continuePlay() {
+    setNextGame(null);
     const newList = [...playedGameIds, nextGame?.igdbId ?? 0];
     updatePlayedGameIds(newList);
     const res = await fetch('/api/random-one', {


### PR DESCRIPTION
Fixes previous 'next game' cover temporarily being displayed